### PR TITLE
Feature/scielo chapters

### DIFF
--- a/bookloader.py
+++ b/bookloader.py
@@ -4,7 +4,7 @@ import pandas as pd
 import isbn_hyphenate
 import json
 import pymarc
-import roman as roman
+import roman
 from onix.book.v3_0.reference.strict import Onixmessage
 from xsdata.formats.dataclass.parsers import XmlParser
 from thothlibrary import ThothClient

--- a/bookloader.py
+++ b/bookloader.py
@@ -36,10 +36,13 @@ class BookLoader:
     publisher_url = None
     cache_contributors = True
     cache_institutions = True
+    cache_series = False
+    cache_issues = False
     cache_pagination_size = 20000
     all_contributors = {}
     all_institutions = {}
     all_series = {}
+    all_issues = {}
     encoding = "utf-8"
     header = 0
     separation = ","
@@ -179,6 +182,18 @@ class BookLoader:
                     self.all_institutions[i.institutionName] = i.institutionId
                     if i.ror:
                         self.all_institutions[i.ror] = i.institutionId
+
+        if self.cache_series:
+            # create cache of all existing series using pagination
+            for offset in range(0, self.thoth.series_count(), self.cache_pagination_size):
+                for s in self.thoth.serieses(limit=self.cache_pagination_size, offset=offset):
+                    self.all_series[s.seriesName] = s.seriesId
+
+        if self.cache_issues:
+            # create cache of all existing issues using pagination
+            for offset in range(0, self.thoth.issue_count(), self.cache_pagination_size):
+                for issue in self.thoth.issues(limit=self.cache_pagination_size, offset=offset):
+                    self.all_issues[issue.work.workId] = issue.issueId
 
     def prepare_csv_file(self):
         """Read CSV, convert empties to None and rename duplicate columns"""

--- a/edituschapterloader.py
+++ b/edituschapterloader.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Load EDITUS metadata into Thoth"""
+
+from scieloloader import SciELOChapterLoader
+
+
+class EDITUSChapterLoader(SciELOChapterLoader):
+    """EDUEPB specific logic to ingest chapter metadata from JSON into Thoth"""
+    publisher_name = "EDITUS"
+    publisher_url = "http://www.uesc.br/editora/"

--- a/editusloader.py
+++ b/editusloader.py
@@ -3,6 +3,7 @@
 
 from scieloloader import SciELOBookLoader
 
+
 class EDITUSLoader(SciELOBookLoader):
     """EDITUS specific logic to ingest book metadata from JSON into Thoth"""
     publisher_name = "EDITUS"

--- a/editusloader.py
+++ b/editusloader.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 """Load EDITUS metadata into Thoth"""
 
-from scieloloader import SciELOLoader
+from scieloloader import SciELOBookLoader
 
-class EDITUSLoader(SciELOLoader):
-    """EDITUS specific logic to ingest metadata from JSON into Thoth"""
+class EDITUSLoader(SciELOBookLoader):
+    """EDITUS specific logic to ingest book metadata from JSON into Thoth"""
     publisher_name = "EDITUS"
     publisher_url = "http://www.uesc.br/editora/"

--- a/eduepbchapterloader.py
+++ b/eduepbchapterloader.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Load EDUEPB metadata into Thoth"""
+
+from scieloloader import SciELOChapterLoader
+
+class EDUEPBChapterLoader(SciELOChapterLoader):
+    """EDUEPB specific logic to ingest chapter metadata from JSON into Thoth"""
+    publisher_name = "EDUEPB"
+    publisher_url = "https://books.scielo.org/eduepb/"
+

--- a/eduepbchapterloader.py
+++ b/eduepbchapterloader.py
@@ -3,8 +3,8 @@
 
 from scieloloader import SciELOChapterLoader
 
+
 class EDUEPBChapterLoader(SciELOChapterLoader):
     """EDUEPB specific logic to ingest chapter metadata from JSON into Thoth"""
     publisher_name = "EDUEPB"
     publisher_url = "https://books.scielo.org/eduepb/"
-

--- a/eduepbloader.py
+++ b/eduepbloader.py
@@ -3,8 +3,8 @@
 
 from scieloloader import SciELOBookLoader
 
+
 class EDUEPBLoader(SciELOBookLoader):
     """EDUEPB specific logic to ingest book metadata from JSON into Thoth"""
     publisher_name = "EDUEPB"
     publisher_url = "https://books.scielo.org/eduepb/"
-

--- a/eduepbloader.py
+++ b/eduepbloader.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """Load EDUEPB metadata into Thoth"""
 
-from scieloloader import SciELOLoader
+from scieloloader import SciELOBookLoader
 
-class EDUEPBLoader(SciELOLoader):
-    """EDUEPB specific logic to ingest metadata from JSON into Thoth"""
+class EDUEPBLoader(SciELOBookLoader):
+    """EDUEPB specific logic to ingest book metadata from JSON into Thoth"""
     publisher_name = "EDUEPB"
     publisher_url = "https://books.scielo.org/eduepb/"
 

--- a/loader.py
+++ b/loader.py
@@ -18,7 +18,7 @@ from uwploader import UWPLoader
 from lseloader import LSELoader
 from editusloader import EDITUSLoader
 from eduepbloader import EDUEPBLoader
-from scieloloader import SciELOLoader
+from eduepbchapterloader import EDUEPBChapterLoader
 from ubiquityloader import UbiquityPressesLoader
 from uolloader import UOLLoader
 
@@ -35,6 +35,7 @@ LOADERS = {
     "LSE": LSELoader,
     "EDITUS": EDITUSLoader,
     "EDUEPB": EDUEPBLoader,
+    "EDUEPB-chapters": EDUEPBChapterLoader,
     "Ubiquity-presses": UbiquityPressesLoader,
     "UOL": UOLLoader,
 }

--- a/loader.py
+++ b/loader.py
@@ -19,6 +19,7 @@ from lseloader import LSELoader
 from editusloader import EDITUSLoader
 from eduepbloader import EDUEPBLoader
 from eduepbchapterloader import EDUEPBChapterLoader
+from edituschapterloader import EDITUSChapterLoader
 from ubiquityloader import UbiquityPressesLoader
 from uolloader import UOLLoader
 
@@ -34,6 +35,7 @@ LOADERS = {
     "UWP": UWPLoader,
     "LSE": LSELoader,
     "EDITUS": EDITUSLoader,
+    "EDITUS-chapters": EDITUSChapterLoader,
     "EDUEPB": EDUEPBLoader,
     "EDUEPB-chapters": EDUEPBChapterLoader,
     "Ubiquity-presses": UbiquityPressesLoader,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-thothlibrary==0.24.0
+thothlibrary==0.25.0
 pandas==2.1.1
 requests==2.31.0
 isbn-hyphenate==1.0.4

--- a/scieloloader.py
+++ b/scieloloader.py
@@ -6,7 +6,6 @@ import logging
 import sys
 import re
 import roman
-from chapterloader import ChapterLoader
 from bookloader import BookLoader
 from thothlibrary import ThothError
 
@@ -216,7 +215,7 @@ class SciELOLoader(BookLoader):
             self.thoth.create_location(location)
             logging.info(f"created location with publicationId {publication_id}")
 
-class SciELOChapterLoader(SciELOLoader, ChapterLoader):
+class SciELOChapterLoader(SciELOLoader):
     """SciELO specific logic to ingest chapter metadata from JSON into Thoth"""
 
     def run(self):

--- a/scieloloader.py
+++ b/scieloloader.py
@@ -177,6 +177,7 @@ class SciELOChapterLoader(SciELOShared, BookLoader, ChapterLoader):
                 chapter_work = self.thoth.work_by_id(chapter_id)
                 self.create_languages(record, chapter_work)
                 self.create_contributors(record, chapter_work)
+                # TODO: create publications
 
                 if relation_ordinal == "00":
                     relation_ordinal = 1
@@ -195,111 +196,13 @@ class SciELOChapterLoader(SciELOShared, BookLoader, ChapterLoader):
                     logging.info("languages updated")
                     self.create_contributors(record, chapter_work)
                     logging.info("contributors updated")
-                    # reset relation_ordinal for chapters to 1 when we get to a new book in JSON
-                    # if book_title != previous_book_title:
-                    #     relation_ordinal = 1
-                    # previous_book_title = book_title
-                    # relation_ordinal += 1
-                # if update fails, log the error and exit the import
+                    # TODO: update publications?
                 except ThothError as t:
                     logging.error(f"Failed to update chapter: {chapter['title']}, exception: {t}")
                     sys.exit(1)
 
             logging.info("*************")
             logging.info("*************")
-
-
-
-            # # case where there are some or all existing chapters that match a PDF URL
-            # # (which contains book Work's internal ID) in Thoth
-            # try:
-            #     # use book_internal_id to search in Thoth for all works containing internal ID
-            #     # that are type book chapter
-            #     matching_chapters = self.get_chapters_by_string(book_internal_id)
-            #     logging.info(f"matching chapters: {matching_chapters}")
-            #     found_match = False
-            #     # iterate over the array of matching chapters
-            #     for chapter in matching_chapters:
-            #         # look in the chapter Work at the title field
-            #         # if the JSON matches an existing title, update it
-            #         if chapter.fullTitle == record["title"]:
-            #             logging.info(f"{chapter.fullTitle} is in Thoth; updating Thoth from JSON")
-            #             try:
-            #                 work = self.get_work(record, self.imprint_id, book_id)
-            #                 chapter.update((k, v) for k, v in work.items() if v is not None)
-            #                 chapter_id = self.thoth.update_work(chapter)
-            #                 logging.info(f"updated chapter: {chapter['title']}")
-            #                 chapter_work = self.thoth.work_by_id(chapter_id)
-            #                 self.create_languages(record, chapter_work)
-            #                 logging.info("languages updated")
-            #                 self.create_contributors(record, chapter_work)
-            #                 logging.info("contributors updated")
-            #                 # reset relation_ordinal for chapters to 1 when we get to a new book in JSON
-            #                 if book_title != previous_book_title:
-            #                     relation_ordinal = 1
-            #                 previous_book_title = book_title
-            #                 relation_ordinal += 1
-            #             # if update fails, log the error and exit the import
-            #             except ThothError as t:
-            #                 logging.error(f"Failed to update chapter: {chapter['title']}, exception: {t}")
-            #                 sys.exit(1)
-            #             found_match = True
-
-            #     # Case if other Chapters were found, but not the specific Chapter
-            #     if not found_match:
-            #         logging.error(f"Some chapters found for work, but not {record['title']}; try deleting all chapters from Work in Thoth and re-running loader")
-            #         sys.exit(1)
-
-            # except (IndexError, AttributeError):
-            #     logging.info(f'No chapters found containing: {book_internal_id}, adding chapter to Work')
-
-
-
-
-
-            # if chapters_in_thoth == []:
-            #     logging.info("No chapters in Thoth with this title; creating new chapter")
-
-            # if chapters_in_thoth:
-                # logging.info(chapters_in_thoth_raw)
-
-                #for chapter in chapters_in_thoth:
-                    # logging.info(chapter.relations)
-
-
-                # try:
-                #     # try to find a book in Thoth with the same title as "monograph_title" in JSON
-                #     thoth_book_landing_page = self.get_book_by_title(book_title)['landingPage']
-                #     logging.info("found book in Thoth")
-                #     # loop through all chapters in Thoth with this name and try to find a Book Work
-                #     # with matching landingPage, which is a unique URL in SciELO shared in both records.
-                #     for chapter in chapters_in_thoth:
-                #         logging.info(f"chapter: {chapter}")
-                #         thoth_chapter_landing_page = chapter['landingPage']
-                #         if thoth_chapter_landing_page == thoth_book_landing_page:
-                #             logging.info(f"Chapter {chapter['title']} and Book {book_title} already in Thoth; attempting Chapter update from JSON")
-
-                #         # handles case where a chapter has a common name already in Thoth (e.g. "Referências"), but is a new chapter and hasn't been added to the relevant Book
-                #         elif json_landing_page not in chapters_in_thoth_raw and json_landing_page == thoth_book_landing_page:
-                #             logging.info(f"JSON landing page: {json_landing_page}")
-                #             logging.info(f"chapters_in_thoth raw: {chapters_in_thoth_raw}")
-                #             logging.info("Chapter name was found in Thoth but doesn't match any existing chapter by landingPage; creating new chapter")
-                #             work = self.get_work(record, self.imprint_id, book_id)
-                #             chapter_id = self.thoth.create_work(work)
-                #             chapter_work = self.thoth.work_by_id(chapter_id)
-                #             self.create_languages(record, chapter_work)
-                #             self.create_contributors(record, chapter_work)
-                #             # reset relation_ordinal for chapters to 1 when we get to a new book in JSON
-                #             if book_title != previous_book_title:
-                #                 relation_ordinal = 1
-                #             previous_book_title = book_title
-                #             self.create_chapter_relation(book_id, chapter_id, relation_ordinal)
-                #             relation_ordinal += 1
-                #         else:
-                #             logging.info("Chapter name was found in Thoth, and chapter already exists by landingPage; skipping")
-                # except:
-                #     logging.info("could not find book in Thoth to associate with Chapter, exiting")
-                #     sys.exit(1)
 
     def get_work(self, record, imprint_id, book_id):
         """Returns a dictionary with all attributes of a 'work'

--- a/scieloloader.py
+++ b/scieloloader.py
@@ -4,8 +4,21 @@
 import json
 import logging
 import sys
+# from chapterloader import ChapterLoader
 from bookloader import BookLoader
 from thothlibrary import ThothError
+
+class SciELOChapterLoader(BookLoader):
+    """SciELO specific logic to ingest chapter metadata from JSON into Thoth"""
+    import_format = "JSON"
+    single_imprint = True
+    cache_institutions = False
+
+    def run(self):
+        """Process JSON and call Thoth to insert its data"""
+        for record in self.data:
+            book_title = record["monograph_title"]
+            logging.info(f"book_title: {book_title}"
 
 
 class SciELOLoader(BookLoader):

--- a/scieloloader.py
+++ b/scieloloader.py
@@ -5,12 +5,12 @@ import json
 import logging
 import sys
 import re
-import roman as roman
+import roman
 from chapterloader import ChapterLoader
 from bookloader import BookLoader
 from thothlibrary import ThothError
 
-class SciELOShared(BookLoader):
+class SciELOLoader(BookLoader):
     """Shared logic for SciELO book and chapter loaders"""
     import_format = "JSON"
     single_imprint = True
@@ -216,7 +216,7 @@ class SciELOShared(BookLoader):
             self.thoth.create_location(location)
             logging.info(f"created location with publicationId {publication_id}")
 
-class SciELOChapterLoader(SciELOShared, BookLoader, ChapterLoader):
+class SciELOChapterLoader(SciELOLoader, ChapterLoader):
     """SciELO specific logic to ingest chapter metadata from JSON into Thoth"""
 
     def run(self):
@@ -318,9 +318,9 @@ class SciELOChapterLoader(SciELOShared, BookLoader, ChapterLoader):
             # haven't found any in JSON so far, but just in case
             else:
                 try:
-                    first_page = fromRoman(first_page.upper())
-                    last_page = fromRoman(last_page.upper())
-                    page_count = last_page - first_page + 1
+                    first_page_int = roman.fromRoman(first_page.upper())
+                    last_page_int = roman.fromRoman(last_page.upper())
+                    page_count = last_page_int - first_page_int + 1
                 except ValueError:
                     logging.error(f"Page numbers are not integer or roman numeral: {first_page}–{last_page}; skipping adding page numbers to Thoth")
                     pass
@@ -396,7 +396,7 @@ class SciELOChapterLoader(SciELOShared, BookLoader, ChapterLoader):
                 doi = doi
         return doi
 
-class SciELOLoader(SciELOShared, BookLoader):
+class SciELOBookLoader(SciELOLoader):
     """SciELO specific logic to ingest metadata from Book JSON into Thoth"""
 
     def run(self):


### PR DESCRIPTION
Book and Chapter loader for bulk ingest of chapter metadata from SciELO Books JSON. Chapter loader and previously completed book loader have been combined into one file, `scieloloader.py`, with significant refactoring of the original book loader to reuse methods between the two classes whenever possible, given the somewhat similar structure of the chapter and book JSON metadata.

This loader has been tested with book and chapter metadata for EDITUS and EDUEPB. However, errors in the JSON for other publishers may produce errors that will need to be addressed in subsequent iterations of the loader.
